### PR TITLE
Tr tool

### DIFF
--- a/src/preamble.tex
+++ b/src/preamble.tex
@@ -1,10 +1,16 @@
 \documentclass[\OPTmodes]{book}
 
 % 용어 모음
-% 스크립트와 같이 사용하시려면, "알파벳 역순으로" 정렬해주시기를 부탁드립니다!
-% 알파벳 역순이 아니라도, 다른 용어의 일부인 용어들은 되도록 뒤에 와야 합니다.
-% 이를테면, parameter가 formal parameter 앞쪽으로 오게 되면,
+
+% 꼭 \newcommand{}{} % ~~~ 꼴로 써 주셔야 합니다! 
+% 짜놓은 스크립트가 이 사실을 적극적으로 이용합니다.
+% 만약 "이 단어는 매크로 적용하면 안 되겠다"는 게 있다면, % 이후에 $$$$$$$$$$와 같이 써 주세요
+
+% 다른 용어의 일부인 용어들은 되도록 뒤에 와야 합니다.
+% parameter가 formal parameter 앞쪽으로 오게 되면,
 % Formal \trParameter 같은 일이 생깁니다.
+% (이런 경우가 자동적으로 핸들링되게끔 고칠 예정이 있습니다만, 그게 정확히 어찌 하면 좋을지가 조금 막막합니다.)
+
 \newcommand{\trComposition}{합성} % composition
 \newcommand{\trCategoryTheory}{카테고리 이론} % category theory
 \newcommand{\trCategory}{카테고리} % category

--- a/src/preamble.tex
+++ b/src/preamble.tex
@@ -1,6 +1,10 @@
 \documentclass[\OPTmodes]{book}
 
 % 용어 모음
+% 스크립트와 같이 사용하시려면, "알파벳 역순으로" 정렬해주시기를 부탁드립니다!
+% 알파벳 역순이 아니라도, 다른 용어의 일부인 용어들은 되도록 뒤에 와야 합니다.
+% 이를테면, parameter가 formal parameter 앞쪽으로 오게 되면,
+% Formal \trParameter 같은 일이 생깁니다.
 \newcommand{\trComposition}{합성} % composition
 \newcommand{\trCategoryTheory}{카테고리 이론} % category theory
 \newcommand{\trCategory}{카테고리} % category
@@ -18,8 +22,8 @@
 \newcommand{\trSymbolic}{심볼릭} % symbolic
 \newcommand{\trHigherOrderFunction}{고계 함수} % higher-order function
 \newcommand{\trArgument}{인자} % argument
-\newcommand{\trParameter}{매개 변수} % parameter
 \newcommand{\trFormalParameter}{형식 매개 변수} % formal parameter
+\newcommand{\trParameter}{매개 변수} % parameter
 %
 
 

--- a/src/preamble.tex
+++ b/src/preamble.tex
@@ -2,17 +2,17 @@
 
 % 용어 모음
 \newcommand{\trComposition}{합성} % composition
-\newcommand{\trCategory}{카테고리} % category
 \newcommand{\trCategoryTheory}{카테고리 이론} % category theory
-\newcommand{\trSideEffect}{사이드 이펙트} % category
+\newcommand{\trCategory}{카테고리} % category
+\newcommand{\trSideEffect}{사이드 이펙트} % side effect
 \newcommand{\trObject}{객체} % object
 \newcommand{\trArrow}{화살표} % arrow
 \newcommand{\trAssociativity}{결합성} %associativity
 \newcommand{\trIdentityMorphism}{항등사상} % identity morphism
-\newcommand{\trIdentity}{아이덴티티} % identity morphism
+\newcommand{\trIdentity}{아이덴티티} % identity
 \newcommand{\trMorphism}{사상} % morphism
 \newcommand{\trUnit}{항등원} % unit
-\newcommand{\trFunctionBody}{정의} % (function) body
+\newcommand{\trFunctionBody}{정의} % $$$$$$$$$$$$$$
 \newcommand{\trExpression}{표현식} % expression
 \newcommand{\trStatement}{문장} % statement
 \newcommand{\trSymbolic}{심볼릭} % symbolic

--- a/src/trhelper.py
+++ b/src/trhelper.py
@@ -39,8 +39,8 @@ def one():
     with open(name,"r",encoding='utf-8') as f:
         d = f.read()
     for tr,word in word_list:
-        d = d.replace(word[0].upper()+word[1:],tr+" ")
-        d = d.replace(word,tr+" ")
+        d = d.replace(" "+word[0].upper()+word[1:]," "+tr+" ")
+        d = d.replace(" "+word," "+tr+" ")
     with open(name,"w",encoding='utf-8') as f:
         f.write(d)
 
@@ -55,12 +55,15 @@ def two():
     for i in [x for x in set(criterion_two.findall(d)) if (x not in jargon_list)]:
         print("\\newcommand{"+i+"}{} % ")
 
+def db(match_obj):
+    return match_obj.group(1)+'\\'+match_obj.group(2)
+
 def three():
     print("!!주의!! 본 작업은 롤백이 안 됩니다.")
     name = get_file_from_ch_name()
     with open(name,"r",encoding='utf-8') as f:
         d = f.read()
-    d = re.sub(r'(?<=\\tr[A-Za-z])(이|가|을|를|와|과|로|으로|은|는|라|이라)',lambda x: '\\'+x[0],d)
+    d = re.sub(r'(\\tr[A-Za-z]+)(이|가|을|를|와|과|로|으로|은|는|라|이라)',db,d)
     with open(name,"w",encoding='utf-8') as f:
         f.write(d)
     
@@ -87,4 +90,3 @@ def zero():
 
 if __name__=="__main__":
     zero()
-    

--- a/src/trhelper.py
+++ b/src/trhelper.py
@@ -1,0 +1,90 @@
+import re
+from pathlib import Path
+
+crit = re.compile(r'\\newcommand{\\tr')
+c = re.compile(r'\\tr[a-zA-Z]+')
+cc = re.compile(r'[^%]+$')
+with open("preamble.tex","r",encoding='utf-8') as f:
+    d = [x.strip() for x in f.readlines() if crit.match(x)]
+
+word_list = []
+for line in d:
+    try:
+        word_list.append((c.search(line)[0].strip(),cc.search(line)[0].strip()))
+    except:
+        pass
+
+tr_list = [x[0] for x in word_list]
+jargon_list = [x[1] for x in word_list]
+for i in word_list:
+    print(i)
+
+def get_file_from_ch_name():
+    ch = input("챕터를 입력해주세요(1.1, 3.3 등의 포맷)\r\n")
+    p = Path("./content/"+ch.strip())
+    for i in [x.name for x in p.iterdir()]:
+        if i.endswith(".tex"):
+            name = i
+    try:
+        return "./content/"+ch.strip()+"/"+name
+    except NameError:
+        raise NameError("Invalid chapter name")
+
+def one():
+    print("!!주의!! 본 작업은 롤백이 안 됩니다.")
+    print("또한, 작업을 2번 실행하시게 되면 \\tr\\trCategory 같은 꼴의 무언가가 생깁니다.")
+    print("\\newcommand{\\tr~~~}{(용어)} % ~~ 포맷을 가지고 돌아가는 프로그램입니다.")
+    print("주석을 제대로 쓰셨는지 다시 한 번 확인 부탁드립니다.")
+    name = get_file_from_ch_name()
+    with open(name,"r",encoding='utf-8') as f:
+        d = f.read()
+    for tr,word in word_list:
+        d = d.replace(word[0].upper()+word[1:],tr+" ")
+        d = d.replace(word,tr+" ")
+    with open(name,"w",encoding='utf-8') as f:
+        f.write(d)
+
+
+def two():
+    print("본 작업은 파일의 내용을 바꾸지 않습니다.")
+    print("출력되는 내용을 프리앰블에 복붙해주세요")
+    name = get_file_from_ch_name()
+    with open(name,"r",encoding = 'utf-8') as f:
+        d = f.read()
+    criterion_two = re.compile(r'\\tr[A-Za-z]+')
+    for i in [x for x in set(criterion_two.findall(d)) if (x not in jargon_list)]:
+        print("\\newcommand{"+i+"}{} % ")
+
+def three():
+    print("!!주의!! 본 작업은 롤백이 안 됩니다.")
+    name = get_file_from_ch_name()
+    with open(name,"r",encoding='utf-8') as f:
+        d = f.read()
+    d = re.sub(r'(?<=\\tr[A-Za-z])(이|가|을|를|와|과|로|으로|은|는|라|이라)',lambda x: '\\'+x[0],d)
+    with open(name,"w",encoding='utf-8') as f:
+        f.write(d)
+    
+def zero():
+    print("preamble 스크레이핑 완료. ")
+    print("!주의! 본 스크립트로 인한 변화는 롤백이 불가능합니다. 꼭 git commit 후 사용해주세요")
+    print("1: 현재 preamble에 있는 용어를 특정 챕터에 적용")
+    print("2: 특정 챕터에 있는 용어 중, preamble에 없는 것을 전부 프린트하기.")
+    print("3: 특정 챕터의 텍스트에 자동 조사 붙이기")
+    while True:
+        a = input("어느 기능을 사용하시겠어요?\r\n")
+        a = a.strip()
+        if a == '1':
+            one()
+            break
+        elif a == '2':
+            two()
+            break
+        elif a == '3':
+            three()
+            break
+        else:
+            print("1, 2, 3 중 하나를 입력해주시기 바랍니다.")
+
+if __name__=="__main__":
+    zero()
+    


### PR DESCRIPTION
src(preamble 있는 쪽)에 trhelper.py 라는 파일을 만들어놨습니다. 
해당 경로에서 `python trhelper.py` 하시면 됩니다.

기능은 3개를 넣어놨는데
1: 현재 preamble에 있는 용어를 특정 챕터에 적용
2: 특정 챕터에 있는 용어 중, preamble에 없는 것을 전부 프린트하기.
3: 특정 챕터의 텍스트에 자동 조사 붙이기
이렇게이구요, 1.3에만 테스트해봤는데 잘 돌아갑니다.

다만 지금 상태에선 기능 1은 좀 조심해서 써야 합니다. 일부 단어(eg. categories)의 경우 복수형이 단수형이랑 조금 다르게 생겨서(y -> ies), categories가 \trCategory로 치환되지 않는 등의 문제가 생깁니다.

이 문제를 해결(?)할 방법으로는 3가지가 떠오릅니다.
1. 영어 문법책에서, 우리가 쓸 만한 복수형 변환 법칙을 전부 찾아서, 코드가 단어 원형만 가지고 모든 것을 알아서 하게끔 하는 것 (이게 되....나요?)
2. preamble에 \newcommand{\trAAA}{} % aaa, bbb, ccc같이 쓰면, 우리가 고른 텍스트에 있는 aaa, bbb, ccc가 모두 \trAAA로 대체되게끔 코드를 짜는 것 (프리앰블 쓰기 엄청나게 귀찮을 것 같아요)
3. 일단 그냥 냅두고 정 불편하면 나중에 다시 고치는 것
그런데 1, 2는 구현법이 지금은 잘 생각이 안 납니다.

그래서 일단 머지시켜두고, 이 브랜치는 유지하면서 조금조금씩 필요한 기능을 더해가면 어떨까 합니다.

어떻게 보시는지 궁금합니다. 일단 1이나 2를 구현하고 다시 오는 게 나을까요?